### PR TITLE
Changed method for registering modeladmin

### DIFF
--- a/wagtailtranslations/wagtail_hooks.py
+++ b/wagtailtranslations/wagtail_hooks.py
@@ -7,11 +7,13 @@ from wagtail.wagtailcore import hooks
 from .models import Language, TranslatedPage
 
 
-@modeladmin_register
 class LanguageModelAdmin(ModelAdmin):
     model = Language
     menu_icon = 'fa-language'
     add_to_settings_menu = True
+
+
+modeladmin_register(LanguageModelAdmin)
 
 
 class TranslationListingButton(Button):


### PR DESCRIPTION
Because `modeladmin_register` doesn't return the class it shouldn't be used as a decorator