### PR TITLE
Wagtail 2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.sqlite*
 .tox/
 build/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,7 @@ Wagtail translations
 ====================
 
 A plugin for Wagtail that provides page translations.
+By extending your pages with the models included in this package users will be redirected to pages in (or closest to) their language.
 
 Installing
 ==========
@@ -25,7 +26,8 @@ Add it to your ``INSTALLED_APPS``:
 
 
 
-It works with Wagtail 2.0 and upwards.
+It works with Wagtail 2.2 and upwards.
+Check versions before 2.0 for compatability with older versions of wagtail.
 
 Quick start
 ===========

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Add it to your ``INSTALLED_APPS``:
 
 
 
-It works with Wagtail 1.7 and upwards.
+It works with Wagtail 2.0 and upwards.
 
 Quick start
 ===========
@@ -49,9 +49,9 @@ Define a translated model:
 
 .. code-block:: python
 
-    from wagtail.wagtailadmin.edit_handlers import FieldPanel
-    from wagtail.wagtailcore.fields import RichTextField
-    from wagtail.wagtailcore.models import Page
+    from wagtail.admin.edit_handlers import FieldPanel
+    from wagtail.core.fields import RichTextField
+    from wagtail.core.models import Page
     from wagtailtranslations.models import TranslatedPage
 
     class ContentPage(TranslatedPage, Page):

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     url='https://github.com/takeflight/wagtailtranslations/',
 
     install_requires=[
-        'wagtail>=1.7',
-        'wagtailfontawesome~=1.0.6',
+        'wagtail>=2.0',
+        'wagtailfontawesome~=1.0',
     ],
     zip_safe=False,
     license='BSD License',

--- a/tests/app/migrations/0001_initial.py
+++ b/tests/app/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.wagtailcore.fields
+import wagtail.core.fields
 
 
 class Migration(migrations.Migration):
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, to='wagtailcore.Page')),
                 ('translatedpage_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailtranslations.TranslatedPage')),
-                ('body', wagtail.wagtailcore.fields.RichTextField()),
+                ('body', wagtail.core.fields.RichTextField()),
             ],
             options={
                 'abstract': False,

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,6 +1,6 @@
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
-from wagtail.wagtailcore.fields import RichTextField
-from wagtail.wagtailcore.models import Page
+from wagtail.admin.edit_handlers import FieldPanel
+from wagtail.core.fields import RichTextField
+from wagtail.core.models import Page
 
 from wagtailtranslations.models import (
     AbstractTranslationIndexPage, TranslatedPage)

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,8 +1,8 @@
-import wagtail.wagtailadmin.urls
-import wagtail.wagtailcore.urls
+import wagtail.admin.urls
+import wagtail.core.urls
 from django.conf.urls import include, url
 
 urlpatterns = [
-    url(r'^admin/', include(wagtail.wagtailadmin.urls)),
-    url(r'', include(wagtail.wagtailcore.urls)),
+    url(r'^admin/', include(wagtail.admin.urls)),
+    url(r'', include(wagtail.core.urls)),
 ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -44,7 +44,7 @@ DEBUG = True
 USE_TZ = True
 TIME_ZONE = 'Australia/Hobart'
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,17 +8,17 @@ INSTALLED_APPS = [
     'modelcluster',
     'wagtailtranslations',
 
-    'wagtail.wagtailcore',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtailusers',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailsnippets',
-    'wagtail.wagtailsearch',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailimages',
+    'wagtail.core',
+    'wagtail.admin',
+    'wagtail.users',
+    'wagtail.sites',
+    'wagtail.snippets',
+    'wagtail.search',
+    'wagtail.documents',
+    'wagtail.images',
     'wagtail.contrib.modeladmin',
-    'wagtail.contrib.wagtailroutablepage',
-    'wagtail.contrib.wagtailstyleguide',
+    'wagtail.contrib.routable_page',
+    'wagtail.contrib.styleguide',
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -53,7 +53,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.core.middleware.SiteMiddleware',
 ]
 
 TEMPLATES = [

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,5 @@
 import os
 
-
 INSTALLED_APPS = [
     'tests.app',
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{34,35}-dj{110}-wt{17}
+	py{34,35}-dj{110}-wt{22}
 	isort,flake8
 
 
@@ -11,7 +11,7 @@ commands = python runtests.py {posargs}
 
 deps =
 	dj110: django~=1.10.0
-	wt17: Wagtail~=1.7.0
+	wt22: Wagtail~=2.2.0
 
 [testenv:isort]
 usedevelop = True

--- a/wagtailtranslations/edit_handlers.py
+++ b/wagtailtranslations/edit_handlers.py
@@ -1,6 +1,8 @@
-from wagtail.admin.edit_handlers import (
-    BaseChooserPanel, PageChooserPanel)
+from wagtail.admin.edit_handlers import BaseChooserPanel
 from wagtail.admin.widgets import AdminPageChooser
+from wagtail.utils.decorators import cached_classmethod
+
+from .models import TranslatedPage
 
 
 class TranslationKeyChooser(AdminPageChooser):

--- a/wagtailtranslations/edit_handlers.py
+++ b/wagtailtranslations/edit_handlers.py
@@ -1,6 +1,6 @@
-from wagtail.wagtailadmin.edit_handlers import (
+from wagtail.admin.edit_handlers import (
     BaseChooserPanel, PageChooserPanel)
-from wagtail.wagtailadmin.widgets import AdminPageChooser
+from wagtail.admin.widgets import AdminPageChooser
 
 
 class TranslationKeyChooser(AdminPageChooser):

--- a/wagtailtranslations/fields.py
+++ b/wagtailtranslations/fields.py
@@ -11,6 +11,7 @@ class BaseTranslationKeyField(models.UUIDField):
     A model field that groups instances that are the same item in different
     languages together with a common key.
     """
+
     def __init__(self, default=uuid.uuid4,
                  db_index=True, **kwargs):
         super(BaseTranslationKeyField, self).__init__(

--- a/wagtailtranslations/forms.py
+++ b/wagtailtranslations/forms.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django import forms
-from wagtail.wagtailadmin.widgets import AdminPageChooser
+from wagtail.admin.widgets import AdminPageChooser
 
 
 class BaseTranslationKeyChoiceField(forms.ModelChoiceField):

--- a/wagtailtranslations/models.py
+++ b/wagtailtranslations/models.py
@@ -7,11 +7,10 @@ from django.db import models
 from django.db.models import Case, Value, When
 from django.http import Http404
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import activate
+from django.utils.translation import ugettext_lazy as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
-from wagtail.admin.forms import (
-    WagtailAdminModelForm, WagtailAdminPageForm)
+from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 from wagtail.core.models import Page
 
 from .fields import PageTranslationKeyField

--- a/wagtailtranslations/models.py
+++ b/wagtailtranslations/models.py
@@ -9,10 +9,10 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import activate
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
-from wagtail.wagtailadmin.forms import (
+from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
+from wagtail.admin.forms import (
     WagtailAdminModelForm, WagtailAdminPageForm)
-from wagtail.wagtailcore.models import Page
+from wagtail.core.models import Page
 
 from .fields import PageTranslationKeyField
 

--- a/wagtailtranslations/version.py
+++ b/wagtailtranslations/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 2, 2)
+version_info = (2, 0, 0)
 version = '.'.join(map(str, version_info))

--- a/wagtailtranslations/wagtail_hooks.py
+++ b/wagtailtranslations/wagtail_hooks.py
@@ -1,8 +1,8 @@
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.wagtailadmin.widgets import Button
-from wagtail.wagtailcore import hooks
+from wagtail.admin.widgets import Button
+from wagtail.core import hooks
 
 from .models import Language, TranslatedPage
 

--- a/wagtailtranslations/wagtail_hooks.py
+++ b/wagtailtranslations/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.admin.widgets import Button
+from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core import hooks
 
 from .models import Language, TranslatedPage


### PR DESCRIPTION
Does the needful for 2.0.
Drops support of pre 2.0 wagtail going forward.
There's no tests for the actual plugin but I ran it ok locally, all the admin functions seemed to work ok.